### PR TITLE
Using the correct shard name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your application's `shard.yml`:
 
 ```yml
 development_dependencies:
-  perf-tools:
+  perf_tools:
     github: crystal-lang/perf-tools
 ```
 


### PR DESCRIPTION
Just an update to the instructions with the correct shard name.

Related: https://github.com/crystal-lang/perf-tools/pull/6