### PR TITLE
Expose method to get the size of a single reference object

### DIFF
--- a/src/perf_tools/mem_prof.cr
+++ b/src/perf_tools/mem_prof.cr
@@ -330,8 +330,9 @@ module PerfTools::MemProf
   #
   # This is the same per-object "size" defined in `.log_object_sizes`.
   #
-  # If *object* is not allocated on the heap, returns zero. Under normal
-  # circumstances, this only happens to string literals.
+  # Returns zero for string literals, as they are never allocated on the heap.
+  # Might also return zero for certain constants which are initialized before
+  # `MemProf` is activated.
   def self.object_size(object : Reference) : UInt64
     alloc_infos = self.alloc_infos
     return 0_u64 unless info = alloc_infos[object.object_id]?

--- a/src/perf_tools/mem_prof.cr
+++ b/src/perf_tools/mem_prof.cr
@@ -326,10 +326,18 @@ module PerfTools::MemProf
     end
   end
 
-  private def self.reachable_set_size(ptr : Void*, size : Int) : UInt64
+  # Returns the total number of heap bytes occupied by *object*.
+  #
+  # This is the same per-object "size" defined in `.log_object_sizes`.
+  #
+  # If *object* is not allocated on the heap, returns zero. Under normal
+  # circumstances, this only happens to string literals.
+  def self.object_size(object : Reference) : UInt64
     alloc_infos = self.alloc_infos
+    return 0_u64 unless info = alloc_infos[object.object_id]?
+
     referenced = PerfTools::Intervals.new
-    referenced.add(ptr.address, size)
+    referenced.add(object.object_id, info.size)
     frontier = referenced.dup
 
     until frontier.empty?


### PR DESCRIPTION
`PerfTools::MemProf.reachable_set_size` originally went unused after its body was merged into `.log_object_sizes`. This PR brings it back and makes it work for single objects on the heap.