### PR TITLE
Fix: current fiber is now stored on Thread (not Scheduler)

### DIFF
--- a/src/perf_tools/fiber_trace.cr
+++ b/src/perf_tools/fiber_trace.cr
@@ -233,7 +233,15 @@ class Crystal::Scheduler
     while stack.last? == Pointer(Void).null
       stack.pop
     end
-    PerfTools::FiberTrace.yield_stack[@current] = stack
+    {% begin %}
+      {% if Crystal::Scheduler.instance_vars.any? { |x| x.name == :thread.id } %}
+        # crystal >= 1.13
+        %current_fiber = @thread.current_fiber
+      {% else %}
+        %current_fiber = @current
+      {% end %}
+      PerfTools::FiberTrace.yield_stack[%current_fiber] = stack
+    {% end %}
 
     previous_def
   end

--- a/src/perf_tools/fiber_trace.cr
+++ b/src/perf_tools/fiber_trace.cr
@@ -233,16 +233,13 @@ class Crystal::Scheduler
     while stack.last? == Pointer(Void).null
       stack.pop
     end
-    {% begin %}
-      {% if Crystal::Scheduler.instance_vars.any? { |x| x.name == :thread.id } %}
-        # crystal >= 1.13
-        %current_fiber = @thread.current_fiber
-      {% else %}
-        %current_fiber = @current
-      {% end %}
-      PerfTools::FiberTrace.yield_stack[%current_fiber] = stack
-    {% end %}
-
+    current_fiber = {% if Crystal::Scheduler.instance_vars.any? { |x| x.name == :thread.id } %}
+                      # crystal >= 1.13
+                      @thread.current_fiber
+                    {% else %}
+                      @current
+                    {% end %}
+    PerfTools::FiberTrace.yield_stack[current_fiber] = stack
     previous_def
   end
 end


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/pull/14554