### PR TITLE
Fix: thread safety of FiberTrace

### DIFF
--- a/src/perf_tools/fiber_trace.cr
+++ b/src/perf_tools/fiber_trace.cr
@@ -178,14 +178,14 @@ module PerfTools::FiberTrace
 
   # :nodoc:
   macro track_fiber(action, current_fiber)
-    stack = Array.new(PerfTools::FiberTrace::STACK_DEPTH + PerfTools::FiberTrace::STACK_SKIP_{{action.upcase.id}}, Pointer(Void).null)
-    Exception::CallStack.unwind_to(Slice.new(stack.to_unsafe, stack.size))
-    stack.truncate(PerfTools::FiberTrace::STACK_SKIP_{{action.upcase.id}}..)
-    while stack.last? == Pointer(Void).null
-      stack.pop
+    %stack = Array.new(PerfTools::FiberTrace::STACK_DEPTH + PerfTools::FiberTrace::STACK_SKIP_{{action.upcase.id}}, Pointer(Void).null)
+    Exception::CallStack.unwind_to(Slice.new(%stack.to_unsafe, %stack.size))
+    %stack.truncate(PerfTools::FiberTrace::STACK_SKIP_{{action.upcase.id}}..)
+    while %stack.last? == Pointer(Void).null
+      %stack.pop
     end
     PerfTools::FiberTrace.lock.synchronize do
-      PerfTools::FiberTrace.{{action.id}}_stack[{{current_fiber}}] = stack
+      PerfTools::FiberTrace.{{action.id}}_stack[{{current_fiber}}] = %stack
     end
   end
 end

--- a/src/perf_tools/fiber_trace.cr
+++ b/src/perf_tools/fiber_trace.cr
@@ -242,16 +242,13 @@ end
 
 class Crystal::Scheduler
   protected def resume(fiber : Fiber) : Nil
-    {% begin %}
-      {% if Crystal::Scheduler.instance_vars.any? { |x| x.name == :thread.id } %}
-        # crystal >= 1.13
-        %current_fiber = @thread.current_fiber
-      {% else %}
-        %current_fiber = @current
-      {% end %}
-      PerfTools::FiberTrace.track_fiber(:yield, %current_fiber)
-    {% end %}
-
+    current_fiber = {% if Crystal::Scheduler.instance_vars.any? { |x| x.name == :thread.id } %}
+                      # crystal >= 1.13
+                      @thread.current_fiber
+                    {% else %}
+                      @current
+                    {% end %}
+    PerfTools::FiberTrace.track_fiber(:yield, current_fiber)
     previous_def
   end
 end


### PR DESCRIPTION
Protects accesses and mutations of traced fibers arrays using a Thread::Mutex (can't use ::Mutex has it would yield fibers). To keep things simple, I don't check for the presence of the `:preview_mt` flag. The impact should be minimal when single threaded. Alternatively I could use `Crystal::SpinLock`.

I also abstracted a `track_fiber` macro to make it easy to use it from custom schedulers, and it avoids a bit of duplication.

With this patch, I can now properly track fibers in a multithreaded [ExecutionContext](https://github.com/ysbaddaden/execution_context) while it previously failed badly.

Fixes the first half of #2 