### PR TITLE
Print scheduler details (ExecutionContext)

### DIFF
--- a/src/core_ext/fiber.cr
+++ b/src/core_ext/fiber.cr
@@ -1,0 +1,14 @@
+# :nodoc:
+class Fiber
+  def status : String
+    if @alive
+      if @context.@resumable == 1
+        "suspended"
+      else
+        "running"
+      end
+    else
+      "dead"
+    end
+  end
+end

--- a/src/perf_tools/scheduler_trace.cr
+++ b/src/perf_tools/scheduler_trace.cr
@@ -36,7 +36,7 @@ module PerfTools::SchedulerTrace
   #
   # Set *details* to true to print individual fiber details.
   def self.every(interval : Time::Span, details = false) : Nil
-    Thread.new("PERFTOOLSSCHED") do
+    Thread.new("PERF-TOOLS") do
       loop do
         Thread.sleep(interval)
         print_runtime_status(details)

--- a/src/perf_tools/scheduler_trace.cr
+++ b/src/perf_tools/scheduler_trace.cr
@@ -73,9 +73,9 @@ module PerfTools::SchedulerTrace
     return unless details
 
     Fiber.unsafe_each do |fiber|
-      if fiber.execution_context? == execution_context
-        print_runtime_status(fiber)
-      end
+      next unless fiber.execution_context? == execution_context
+      next if execution_context.@threads.any? { |thread| thread.current_fiber? == fiber }
+      print_runtime_status(fiber)
     end
   end
 
@@ -90,9 +90,9 @@ module PerfTools::SchedulerTrace
     return unless details
 
     Fiber.unsafe_each do |fiber|
-      if fiber.execution_context? == execution_context
-        print_runtime_status(fiber)
-      end
+      next unless fiber.execution_context? == execution_context
+      next if execution_context.@thread.current_fiber? == fiber
+      print_runtime_status(fiber)
     end
   end
 

--- a/src/perf_tools/scheduler_trace.cr
+++ b/src/perf_tools/scheduler_trace.cr
@@ -1,0 +1,134 @@
+require "./common"
+
+module PerfTools::SchedulerTrace
+  {% if flag?(:unix) %}
+    # Installs a signal handler to call `.print_runtime_status` on demand.
+    #
+    # Uses `SIGUSR1` by default but you may configure another signal, for
+    # example `LibC::SIGRTMIN + 7`. You may also register multiple signals, one
+    # with fiber detail and the another without for example.
+    def self.on(signal : Int32 = Signal::USR1.value, details = false) : Nil
+      # not using Signal#trap so the signal will be handled directly instead
+      # of through the event loop that may have to wait (or be blocked in
+      # the worst case):
+      action = LibC::Sigaction.new
+      action.sa_flags = LibC::SA_RESTART
+      action.sa_sigaction = LibC::SigactionHandlerT.new do |_, _, _|
+        print_runtime_status(details)
+      end
+      LibC.sigemptyset(pointerof(action.@sa_mask))
+      LibC.sigaction(signal, pointerof(action), nil)
+    end
+  {% end %}
+
+  # Starts a thread that will call `.print_runtime_status` every *time* until
+  # the program terminates.
+  def self.every(time : Time::Span, details = false) : Nil
+    Thread.new("PerfToolsSched") do
+      loop do
+        Thread.sleep(time)
+        print_runtime_status(details)
+      end
+    end
+  end
+
+  # Stops the world, prints the status of all runtime schedulers, then resumes
+  # the world.
+  #
+  # Set `details` to true to print individual fiber details.
+  def self.print_runtime_status(details = false) : Nil
+    GC.stop_world
+
+    Crystal::System.print_error("sched.details time=%u\n", Crystal::System::Time.ticks)
+
+    ExecutionContext.unsafe_each do |execution_context|
+      print_runtime_status(execution_context, details)
+    end
+
+    GC.start_world
+  end
+
+  private def self.print_runtime_status(execution_context : ExecutionContext::MultiThreaded, details = false) : Nil
+    Crystal::System.print_error("%s name=%s global_queue.size=%d\n",
+                                execution_context.class.name,
+                                execution_context.name,
+                                execution_context.@global_queue.size)
+
+    execution_context.@threads.each do |thread|
+      print_runtime_status(thread, details)
+    end
+
+    return unless details
+
+    Fiber.unsafe_each do |fiber|
+      if fiber.execution_context? == execution_context
+        print_runtime_status(fiber)
+      end
+    end
+  end
+
+  private def self.print_runtime_status(execution_context : ExecutionContext::SingleThreaded, details = false) : Nil
+    Crystal::System.print_error("%s name=%s global_queue.size=%d\n",
+                                execution_context.class.name,
+                                execution_context.name,
+                                execution_context.@global_queue.size)
+
+    print_runtime_status(execution_context.@thread, details)
+
+    return unless details
+
+    Fiber.unsafe_each do |fiber|
+      if fiber.execution_context? == execution_context
+        print_runtime_status(fiber)
+      end
+    end
+  end
+
+  private def self.print_runtime_status(execution_context : ExecutionContext::Isolated, details = false) : Nil
+    Crystal::System.print_error("%s name=%s\n", execution_context.class.name, execution_context.name)
+    print_runtime_status(execution_context.@thread, details = false)
+  end
+
+  private def self.print_runtime_status(thread : Thread, details = false) : Nil
+    thread_handle =
+      {% if flag?(:linux) %}
+        Pointer(Void).new(thread.@system_handle)
+      {% else %}
+        thread.@system_handle
+      {% end %}
+
+      case scheduler = thread.current_scheduler?
+      when ExecutionContext::MultiThreaded::Scheduler
+        Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
+                                    scheduler.name,
+                                    thread_handle,
+                                    scheduler.@runnables.size,
+                                    scheduler.status)
+      when ExecutionContext::SingleThreaded
+        Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
+                                    scheduler.name,
+                                    thread_handle,
+                                    scheduler.@runnables.size,
+                                    scheduler.status)
+      when ExecutionContext::Isolated
+        Crystal::System.print_error("  Scheduler name=%s thread=%p status=%s\n",
+                                    scheduler.name,
+                                    thread_handle,
+                                    scheduler.status)
+      end
+
+      return unless details
+
+      if fiber = thread.current_fiber?
+        Crystal::System.print_error("    Fiber %p name=%s status=running\n", fiber.as(Void*), fiber.name)
+      end
+  end
+
+  # TODO: print the fiber status: running, queued (local, global), sleeping, suspended, ...
+  private def self.print_runtime_status(fiber : Fiber) : Nil
+    Crystal::System.print_error("  Fiber %p name=%s\n", fiber.as(Void*), fiber.name)
+  end
+
+  # private def self.print_runtime_status(arg : Nil, details = false) : Nil
+  # end
+end

--- a/src/perf_tools/scheduler_trace.cr
+++ b/src/perf_tools/scheduler_trace.cr
@@ -37,7 +37,7 @@ module PerfTools::SchedulerTrace
   #
   # Set `details` to true to print individual fiber details.
   def self.print_runtime_status(details = false) : Nil
-    GC.stop_world
+    Thread.stop_world
 
     Crystal::System.print_error("sched.details time=%u\n", Crystal::System::Time.ticks)
 
@@ -45,7 +45,7 @@ module PerfTools::SchedulerTrace
       print_runtime_status(execution_context, details)
     end
 
-    GC.start_world
+    Thread.start_world
   end
 
   private def self.print_runtime_status(execution_context : ExecutionContext::MultiThreaded, details = false) : Nil

--- a/src/perf_tools/scheduler_trace.cr
+++ b/src/perf_tools/scheduler_trace.cr
@@ -50,9 +50,9 @@ module PerfTools::SchedulerTrace
 
   private def self.print_runtime_status(execution_context : ExecutionContext::MultiThreaded, details = false) : Nil
     Crystal::System.print_error("%s name=%s global_queue.size=%d\n",
-                                execution_context.class.name,
-                                execution_context.name,
-                                execution_context.@global_queue.size)
+      execution_context.class.name,
+      execution_context.name,
+      execution_context.@global_queue.size)
 
     execution_context.@threads.each do |thread|
       print_runtime_status(thread, details)
@@ -69,9 +69,9 @@ module PerfTools::SchedulerTrace
 
   private def self.print_runtime_status(execution_context : ExecutionContext::SingleThreaded, details = false) : Nil
     Crystal::System.print_error("%s name=%s global_queue.size=%d\n",
-                                execution_context.class.name,
-                                execution_context.name,
-                                execution_context.@global_queue.size)
+      execution_context.class.name,
+      execution_context.name,
+      execution_context.@global_queue.size)
 
     print_runtime_status(execution_context.@thread, details)
 
@@ -97,31 +97,31 @@ module PerfTools::SchedulerTrace
         thread.@system_handle
       {% end %}
 
-      case scheduler = thread.current_scheduler?
-      when ExecutionContext::MultiThreaded::Scheduler
-        Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
-                                    scheduler.name,
-                                    thread_handle,
-                                    scheduler.@runnables.size,
-                                    scheduler.status)
-      when ExecutionContext::SingleThreaded
-        Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
-                                    scheduler.name,
-                                    thread_handle,
-                                    scheduler.@runnables.size,
-                                    scheduler.status)
-      when ExecutionContext::Isolated
-        Crystal::System.print_error("  Scheduler name=%s thread=%p status=%s\n",
-                                    scheduler.name,
-                                    thread_handle,
-                                    scheduler.status)
-      end
+    case scheduler = thread.current_scheduler?
+    when ExecutionContext::MultiThreaded::Scheduler
+      Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
+        scheduler.name,
+        thread_handle,
+        scheduler.@runnables.size,
+        scheduler.status)
+    when ExecutionContext::SingleThreaded
+      Crystal::System.print_error("  Scheduler name=%s thread=%p local_queue.size=%u status=%s\n",
+        scheduler.name,
+        thread_handle,
+        scheduler.@runnables.size,
+        scheduler.status)
+    when ExecutionContext::Isolated
+      Crystal::System.print_error("  Scheduler name=%s thread=%p status=%s\n",
+        scheduler.name,
+        thread_handle,
+        scheduler.status)
+    end
 
-      return unless details
+    return unless details
 
-      if fiber = thread.current_fiber?
-        Crystal::System.print_error("    Fiber %p name=%s status=running\n", fiber.as(Void*), fiber.name)
-      end
+    if fiber = thread.current_fiber?
+      Crystal::System.print_error("    Fiber %p name=%s status=running\n", fiber.as(Void*), fiber.name)
+    end
   end
 
   # TODO: print the fiber status: running, queued (local, global), sleeping, suspended, ...


### PR DESCRIPTION
Prints runtime information about a program, either at regular interval, programmatically or on demand (through a signal), with or without the list of fibers (that can be huge). Stops the world to be able to print an accurate map of all execution contexts, 

For example (idle program with a couple additional execution contexts):

```
sched.details time=571371878
ExecutionContext::SingleThreaded name=DEFAULT global_queue.size=0
  Scheduler name=DEFAULT thread=0x7f22d27a9740 local_queue.size=0 status=event-loop
ExecutionContext::SingleThreaded name=ST1 global_queue.size=0
  Scheduler name=ST1 thread=0x7f22cd750700 local_queue.size=0 status=parked
ExecutionContext::SingleThreaded name=ST2 global_queue.size=0
  Scheduler name=ST2 thread=0x7f22ccf4f700 local_queue.size=0 status=parked
```

Requirements:
- [x] ~~Crystal with [Thread.stop_world](https://github.com/crystal-lang/crystal/pull/14729) (merged in 1.14.0)~~
- [x] ~~Crystal with [Fiber::ExecutionContext](https://github.com/ysbaddaden/execution_context) (merged in 1.16.0)~~

Usage:

```crystal
require "perf-tools/scheduler_trace"
require "execution_context"

# print on demand (UNIX only):
PerfTools::SchedulerTrace.on(Signal::USR1, details: true)

# print at regular intervals:
PerfTools::SchedulerTrace.every(5.seconds, details: false)

# print manually:
PerfTools::SchedulerTrace.print_runtime_status(details: true)
```

Specify `details: true` to also print the list of fibers in each execution context.